### PR TITLE
fix(arg parsing): Prevent crash when no positional arg is provided

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -62,7 +62,12 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
-	slog.Debug("create command", slog.String("positional", args[0]))
+	if len(args) == 0 {
+		slog.Debug("create command", "positional", "-")
+	} else {
+		slog.Debug("create command", slog.String("positional", args[0]))
+	}
+
 	printInto()
 
 	// Check node
@@ -87,6 +92,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	tDir := "./redwood-app"
 	if len(args) == 0 {
 		// TODO: Prompt for target directory
+		// slog.Debug("target directory unset, prompting")
+		return fmt.Errorf("Missing target directory")
 	} else {
 		tDir = args[0]
 	}


### PR DESCRIPTION
Without this fix the cli crashes if you don't provide an installation directory
![image](https://github.com/redwoodjs/rw-cli/assets/30793/97c23811-75e4-46d8-87e4-69f25d4321d2)

Now it instead prints a helpful error message
![image](https://github.com/redwoodjs/rw-cli/assets/30793/0f6c82c6-2254-4667-88fd-19b12c2b1f83)
