### PR TITLE
fix(yarn-check): Use realpath to detect corepack

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -344,6 +344,7 @@ func checkNode() error {
 
 func checkYarn() error {
 	yarns := which.All("yarn")
+	realpaths := which.All("realpath")
 	if len(yarns) == 0 {
 		return fmt.Errorf("yarn not found")
 	}
@@ -352,20 +353,38 @@ func checkYarn() error {
 	for _, yarn := range yarns {
 		slog.Debug("yarn found", slog.String("path", yarn))
 
-		// Run `exec env | grep COREPACK_ROOT`
-		out, err := exec.Command(yarn, "exec", "env").Output()
-		if err != nil {
-			slog.Error("failed to run yarn exec env", slog.String("error", err.Error()))
-			return err
-		}
-		sOut := string(out)
 		found := false
-		for _, line := range strings.Split(sOut, "\n") {
-			if strings.Contains(line, "COREPACK_ROOT=") {
-				slog.Debug("yarn is used via corepack", slog.String("line", line))
-				found = true
+
+		if len(realpaths) > 0 {
+			realpath := realpaths[0]
+			yarnPath, err := exec.Command(realpath, yarn).Output()
+
+			if err == nil {
+				// TODO: Figure out Windows support
+				found = strings.Contains(string(yarnPath), "/node_modules/corepack/")
 			}
 		}
+
+		if !found {
+			// Run `yarn exec env | grep COREPACK_ROOT`
+			out, err := exec.Command(yarn, "exec", "env").Output()
+			if err != nil {
+				slog.Error(
+					"failed to run yarn exec env",
+					slog.String("error", err.Error()),
+					slog.String("msg", string(out)),
+				)
+				return err
+			}
+			sOut := string(out)
+			for _, line := range strings.Split(sOut, "\n") {
+				if strings.Contains(line, "COREPACK_ROOT=") {
+					slog.Debug("yarn is used via corepack", slog.String("line", line))
+					found = true
+				}
+			}
+		}
+
 		allCorepack = allCorepack && found
 	}
 


### PR DESCRIPTION
`rw` exits with a non-descript error when checking the yarn installation
![image](https://github.com/redwoodjs/rw-cli/assets/30793/908ef936-121a-46f9-b737-087247f76131)

Even the debug log is pretty unhelpful
![image](https://github.com/redwoodjs/rw-cli/assets/30793/c6a950bc-6264-4ac0-a09e-e5eab9799ab4)
Just says `command failed with error` and `exit status 1`.
No clues as to what actually caused it to fail

With this PR you'd get a more helpful log message:
![image](https://github.com/redwoodjs/rw-cli/assets/30793/3b5f1cf9-bc61-4f85-9f93-71e6f9a95a38)
`No project found in /Users/tobbe/dev/redwood/rw-cli`
`yarn exec <commandName> ...`

And to get around the actual error I implemented a call to `realpath $(which yarn)`. If that check passes I skip `yarn exec env`. If the realpath check fails the code still falls back to `yarn exec env`.

The usage of `yarn exec env` comes from here https://yarnpkg.com/corepack#installation
But it apparently only works if you're already in an initialized yarn project.

The "official" recommended real solution to this seems to be to enable corepack in a temp directory and use that.
https://github.com/nodejs/corepack/issues/113

But before going down that route I just did the `realpath` check for now as that was much easier and faster to implement.

I also asked on the yarn discord about this. See if they come back with any other ideas before we implement anything too crazy here. https://discord.com/channels/226791405589233664/654372321225605128/1205773363981848586